### PR TITLE
Fix same epoch issue

### DIFF
--- a/src/neptune.f90
+++ b/src/neptune.f90
@@ -902,26 +902,28 @@ contains
         ! write(cmess,'(a)') ' pre: request_time '//toString(request_time)//', prop_counter '//toString(prop_counter)//', delta_time '//toString(delta_time)//', reset: '//toString(reset)
         ! call message(cmess, LOG_AND_STDOUT)
 
-        call neptune%numerical_integrator%integrateStep(         &
-                            neptune%gravity_model,               &              ! <->  TYPE  Gravity model
-                            neptune%atmosphere_model,            &              ! <->  TYPE  Atmosphere model
-                            neptune%manoeuvres_model,            &              ! <->  TYPE  Manoeuvres model
-                            neptune%radiation_model,             &              ! <->  TYPE  Radiation model
-                            neptune%satellite_model,             &              ! <->  TYPE  Satellite  model
-                            neptune%solarsystem_model,           &              ! <->  TYPE  Solarsysten model
-                            neptune%thirdbody_model,             &              ! <->  TYPE  Third body model
-                            neptune%tides_model,                 &              ! <->  TYPE  Tides model
-                            neptune%derivatives_model,           &              ! <->  TYPE  Derivatives model
-                            neptune%reduction,                   &              ! <->  TYPE  Reduction
-                            request_time,                        &              ! <--  DBL   requested time (s)
-                            force_no_interpolation,              &              ! <--  LOGI  indicates no interpolation => perfect last step for big changes in acceleration (i.e. maneuvers)
-                            prop_counter,                        &              ! <--> DBL   current time (s)
-                            state_out%r,                         &              ! <--> DBL() radius vector (km)
-                            state_out%v,                         &              ! <--> DBL() velocity vector (km/s)
-                            reset,                               &              ! <--> INT   reset flag
-                            delta_time                           &              ! -->  DBL   propagated time (s)
-                          )
-
+        if (abs(request_time-prop_counter) > epsilon(1.0d0)) then
+          call neptune%numerical_integrator%integrateStep(         &
+                              neptune%gravity_model,               &              ! <->  TYPE  Gravity model
+                              neptune%atmosphere_model,            &              ! <->  TYPE  Atmosphere model
+                              neptune%manoeuvres_model,            &              ! <->  TYPE  Manoeuvres model
+                              neptune%radiation_model,             &              ! <->  TYPE  Radiation model
+                              neptune%satellite_model,             &              ! <->  TYPE  Satellite  model
+                              neptune%solarsystem_model,           &              ! <->  TYPE  Solarsysten model
+                              neptune%thirdbody_model,             &              ! <->  TYPE  Third body model
+                              neptune%tides_model,                 &              ! <->  TYPE  Tides model
+                              neptune%derivatives_model,           &              ! <->  TYPE  Derivatives model
+                              neptune%reduction,                   &              ! <->  TYPE  Reduction
+                              request_time,                        &              ! <--  DBL   requested time (s)
+                              force_no_interpolation,              &              ! <--  LOGI  indicates no interpolation => perfect last step for big changes in acceleration (i.e. maneuvers)
+                              prop_counter,                        &              ! <--> DBL   current time (s)
+                              state_out%r,                         &              ! <--> DBL() radius vector (km)
+                              state_out%v,                         &              ! <--> DBL() velocity vector (km/s)
+                              reset,                               &              ! <--> INT   reset flag
+                              delta_time                           &              ! -->  DBL   propagated time (s)
+                              )
+        end if
+        
         ! write(cmess,'(a)') 'post: request_time '//toString(request_time)//', prop_counter '//toString(prop_counter)//', delta_time '//toString(delta_time)//', reset: '//toString(reset)
         ! call message(cmess, LOG_AND_STDOUT)
                   

--- a/src/neptune.f90
+++ b/src/neptune.f90
@@ -683,6 +683,7 @@ contains
       
         ! write(cmess, '(a)') 'diff = '//date2longstring(epochs(i_epoch))//', step_epochs_sec = '//toString(step_epochs_sec(i_epoch-1))
         ! call message(cmess, LOG_AND_STDOUT)
+        ! call message('Initial request: '//toString(step_epochs_sec(i_epoch-1)), LOG_AND_STDOUT)
       end do
       !write (*,*) step_epochs_sec
       nep_clock = Clock_class(start_epoch_sec, end_epoch_sec, step_epochs_sec)
@@ -801,6 +802,7 @@ contains
 
         if(neptune%getStoreDataFlag()) then
           dtmp = epochs(1)%mjd + prop_counter/86400.d0
+          ! call message("output epoch: "//toString(prop_counter), LOG_AND_STDOUT)
           call neptune%storeData(state_out%r, state_out%v, dtmp)
           ! store covariance matrix data if requested
           if(neptune%numerical_integrator%getCovariancePropagationFlag()) then

--- a/src/neptune.f90
+++ b/src/neptune.f90
@@ -826,23 +826,22 @@ contains
       intermediate_integrator_call = .false.
       if (neptune%derivatives_model%getPertSwitch(PERT_MANEUVERS)) then
 
-        !call message(' Maneuver change at '//toString(epochs(1)%mjd + manoeuvre_change_counter/86400.d0)//' ('//toString(manoeuvre_change_counter)//')', LOGFILE)
+        !call message(' Maneuver change at '//toString(epochs(1)%mjd + manoeuvre_change_counter/86400.d0)//' ('//toString(manoeuvre_change_counter)//')', LOG_AND_STDOUT)
+
+        ! Reset when we are starting into the new maneuver or no-maneuver interval
+        if (abs(prop_counter - manoeuvre_change_counter) < epsilon(1.d0)) then
+          reset = 1
+          !force_no_interpolation = .true.
+          ! reset also the count of subroutine calls to the integrator
+          call neptune%numerical_integrator%resetCountIntegrator()
+          call message(' - Performing reset of intergator now '//toString(epochs(1)%mjd + prop_counter/86400.d0)//'('//toString(prop_counter)//') for upcoming maneuver '//toString(epochs(1)%mjd + manoeuvre_change_counter/86400.d0)//' ('//toString(manoeuvre_change_counter)//')', LOGFILE)
+        end if
 
         ! Get the next manoeuvre change epoch
         upcoming_maneuver_epoch_mjd = neptune%manoeuvres_model%get_upcoming_manoeuvre_change_epoch(epochs(1)%mjd + prop_counter/86400.d0)
         if (upcoming_maneuver_epoch_mjd > 0.d0) then
           manoeuvre_change_counter = (upcoming_maneuver_epoch_mjd - epochs(1)%mjd) * 86400.d0
-          ! Reset when we are starting into the new maneuver or no-maneuver interval
-          if (abs(prop_counter - manoeuvre_change_counter) < epsilon(1.d0)) then
-            reset = 1
-            force_no_interpolation = .true.
-            ! reset also the count of subroutine calls to the integrator
-            call neptune%numerical_integrator%resetCountIntegrator()
-            call message(' - Performing reset of intergator now '//toString(epochs(1)%mjd + prop_counter/86400.d0)//'('//toString(prop_counter)//') for upcoming maneuver '//toString(epochs(1)%mjd + manoeuvre_change_counter/86400.d0)//' ('//toString(manoeuvre_change_counter)//')', LOGFILE)
-          end if
-
-          !call message(' New maneuver change at: '//toString(epochs(1)%mjd + manoeuvre_change_counter/86400.d0)//' ('//toString(manoeuvre_change_counter)//')', LOGFILE)
-          !call message(' - Intermediate integrator call now? '//toString(epochs(1)%mjd + prop_counter/86400.d0)//'('//toString(prop_counter)//') for planned maneuver at '//toString(epochs(1)%mjd + request_time/86400.d0)//' ('//toString(request_time)//')', LOGFILE)
+          !call message(' New maneuver change at: '//toString(epochs(1)%mjd + manoeuvre_change_counter/86400.d0)//' ('//toString(manoeuvre_change_counter)//')', LOG_AND_STDOUT)
           ! Check whether the manoeuvre change is more immenent than the step proposed
           if (.not. flag_backward .and. (manoeuvre_change_counter < request_time .and. manoeuvre_change_counter > prop_counter) &
             .or. flag_backward .and. (manoeuvre_change_counter > request_time .and. manoeuvre_change_counter < prop_counter)) then
@@ -855,14 +854,14 @@ contains
             request_time = manoeuvre_change_counter
             intermediate_integrator_call = .true.
             force_no_interpolation = .true.
-            !neptune%manoeuvres_model%ignore_maneuver_start = .true.
+            neptune%manoeuvres_model%ignore_maneuver_start = .true.
             call message(' - Adding intermediate integrator call now '//toString(epochs(1)%mjd + prop_counter/86400.d0)//'('//toString(prop_counter)//') for planned maneuver at '//toString(epochs(1)%mjd + request_time/86400.d0)//' ('//toString(request_time)//')', LOGFILE)
           end if
         end if
       end if
 
-      !call message(' Going into integrator loop at '//toString(epochs(1)%mjd + prop_counter/86400.d0)//'  ('//toString(prop_counter)//')', LOGFILE)
-      !call message(' prop counter: '//toString(prop_counter)//' request_time: '//toString(request_time)//' difference: '//toString(prop_counter - request_time), LOGFILE)
+      !call message(' Going into integrator loop at '//toString(epochs(1)%mjd + prop_counter/86400.d0)//'  ('//toString(prop_counter)//')', LOG_AND_STDOUT)
+      !call message(' prop counter: '//toString(prop_counter)//' request_time: '//toString(request_time)//' difference: '//toString(prop_counter - request_time), LOG_AND_STDOUT)
 
 
       !====================================================================================
@@ -877,8 +876,10 @@ contains
             ! Reset when the timestep of the integrator is greater than
             if (.not. flag_backward .and. (manoeuvre_change_counter < (prop_counter + neptune%numerical_integrator%get_current_step_size()) .and. manoeuvre_change_counter > prop_counter) &
             .or. flag_backward .and. (manoeuvre_change_counter > (prop_counter - neptune%numerical_integrator%get_current_step_size()) .and. manoeuvre_change_counter < prop_counter)) then
-              ! Force the integrator not to overstep the requested epoch
+              !reset = 1
               force_no_interpolation = .true.
+              ! reset also the count of subroutine calls to the integrator
+              !call neptune%numerical_integrator%resetCountIntegrator()
               call message(' - Forcing no interpolation now '//toString(epochs(1)%mjd + prop_counter/86400.d0)//'('//toString(prop_counter)//') for upcoming maneuver due to time step size '//toString(epochs(1)%mjd + manoeuvre_change_counter/86400.d0)//' ('//toString(manoeuvre_change_counter)//') int step size: '//toString(neptune%numerical_integrator%get_current_step_size()), LOGFILE)
             end if
           end if

--- a/src/neptuneClass.f90
+++ b/src/neptuneClass.f90
@@ -330,8 +330,8 @@ contains
         if (.not. allocated(covMatrix)) allocate(covMatrix(isize))
         if (.not. allocated(setMatrix)) allocate(setMatrix(isize))
 
-        write(cmess,'(a)') 'Initialised index = '//toString(constructor%current_index)//' of '//toString(isize)
-        call message(cmess, LOG_AND_STDOUT)
+        ! write(cmess,'(a)') 'Initialised index = '//toString(constructor%current_index)//' of '//toString(isize)
+        ! call message(cmess, LOG_AND_STDOUT)
 
     end function constructor
 

--- a/src/neptuneClass.f90
+++ b/src/neptuneClass.f90
@@ -117,7 +117,7 @@ module neptuneClass
         type(Derivatives_class) :: derivatives_model                            ! Force model evaluation
         type(Output_class)      :: output                                       ! Output
         type(Version_class)     :: version_model                                ! Version model
-        type(Reduction_type)   :: reduction                                    ! Reduction model
+        type(Reduction_type)    :: reduction                                    ! Reduction model
         type(Correlation_class) :: correlation_model                            ! Correlation model
 
         !=======================================================================
@@ -266,6 +266,9 @@ contains
     !---------------------------------------------------------------------------
     type(Neptune_class) function constructor()
 
+        character(len=255) :: cmess !
+        
+
         ! Instantiate model classes
         constructor%gravity_model = Gravity_class()
         constructor%atmosphere_model = Atmosphere_class()
@@ -326,6 +329,9 @@ contains
         if (.not. allocated(ephem)) allocate(ephem(isize))
         if (.not. allocated(covMatrix)) allocate(covMatrix(isize))
         if (.not. allocated(setMatrix)) allocate(setMatrix(isize))
+
+        write(cmess,'(a)') 'Initialised index = '//toString(constructor%current_index)//' of '//toString(isize)
+        call message(cmess, LOG_AND_STDOUT)
 
     end function constructor
 
@@ -3175,7 +3181,7 @@ contains
       if(.not. this%warned) then                    ! warn that array is full
         cepoch = date2string(ephem(isize)%epoch)
         if(hasFailed()) return
-        write(cmess,'(a)') 'No more data can be added to array. Last element at epoch '//cepoch
+        write(cmess,'(a)') 'No more data can be added to cov-array. Last element at epoch '//cepoch
         call setNeptuneError(E_SPECIAL, WARNING, (/cmess/))
         this%warned = .true.
       end if
@@ -3234,13 +3240,13 @@ contains
 !    end if
 
     this%current_index_set = this%current_index_set + 1
-
+    
     if(this%current_index_set > isize) then  ! array is full
 
       if(.not. this%warned) then ! warn that array is full
 
         cepoch = date2string(ephem(isize)%epoch)
-        write(cmess,'(a)') 'No more data can be added to array. Last element at epoch '//cepoch
+        write(cmess,'(a)') 'No more data can be added to set-array. Last element at epoch '//cepoch
 
         call setNeptuneError(E_SPECIAL, WARNING, (/cmess/))
 
@@ -3287,6 +3293,8 @@ contains
 !------------------------------------
   subroutine storeData(this, r, v, mjd)
 
+    use slam_strings,       only: toString
+        
     class(Neptune_class)               :: this
     real(dp), dimension(3), intent(in) :: r
     real(dp), dimension(3), intent(in) :: v
@@ -3294,7 +3302,7 @@ contains
 
     character(len=*), parameter        :: csubid = 'storeData'
     character(len=20)                  :: cepoch
-    character(len=255)                  :: cmess
+    character(len=255)                 :: cmess
 
     if(isControlled()) then
       if(hasToReturn()) return
@@ -3312,7 +3320,7 @@ contains
       if(.not. this%warned) then ! warn that array is full
 
         cepoch = date2string(ephem(isize)%epoch)
-        write(cmess,'(a)') 'No more data can be added to array. Last element at epoch '//cepoch
+        write(cmess,'(a)') 'No more data can be added to eph-array ('//toString(this%current_index)//'). Last element at epoch: '//cepoch
 
         call setNeptuneError(E_SPECIAL, WARNING, (/cmess/))
 
@@ -3332,6 +3340,10 @@ contains
       ephem(this%current_index)%epoch%jd  = mjd + jd245
 
       call mjd2gd(ephem(this%current_index)%epoch)
+      
+      ! cepoch = date2string(ephem(this%current_index)%epoch)
+      ! write(cmess,'(a)') 'Added date '//cepoch//' at index '//toString(this%current_index)
+      ! call message(cmess, LOG_AND_STDOUT)
 
     end if
 

--- a/src/neptuneClock.f90
+++ b/src/neptuneClock.f90
@@ -43,7 +43,8 @@ module neptuneClock
         real(dp),dimension(:),allocatable  :: step_epochs_sec                   !< intermediate epochs (in seconds)
         logical  :: intermediate_steps_flag                                     !< is .true. when intermediate steps are to be take (requested by user)
         integer  :: intermediate_steps_index                                    !  keeps track of in-array index whilst in intermediate mode
-
+        integer  :: last_index
+        real(dp) :: cumulated_time
     contains
         procedure :: init_counter
         procedure :: switch_backward_propagation
@@ -100,7 +101,8 @@ contains
         constructor_time%flag_cov_save                  = .false.               !< is .true. when an intermediate step for the covariance needs to be saved (like for RK4)
         constructor_time%intermediate_steps_flag        = .false.
         constructor_time%intermediate_steps_index       = 1
-
+        constructor_time%last_index                     = 1
+        constructor_time%cumulated_time                 = 0.d0
         !=====================================================
         !
         ! Consider backward propagation
@@ -136,6 +138,9 @@ contains
     !!
     ! --------------------------------------------------------------------
     function get_next_step(this,neptune,current_time) result(step)
+        use slam_io,                       only: LOG_AND_STDOUT, message
+        use slam_strings,                  only: toString
+
         class(Clock_class)                  :: this
         type(Neptune_class),intent(inout)   :: neptune
         real(dp)           ,intent(in)      :: current_time
@@ -144,28 +149,33 @@ contains
         real(dp), parameter                 :: eps3 = 1.d-3
         real(dp)                            :: cov_step                         !< covariance matrix integration step size / s
         integer                             :: i_index                          !< intermediate step index
-        integer                             :: next_i_index                     !< intermediate step index
-        real(dp)                            :: cumulated_steps
 
-        ! When we are in intermediate steps mode we update the step_size with every request
+        character(len=255)                  :: cmess
+
+        ! update step_size with every request when in intermediate steps mode
         if (this%intermediate_steps_flag) then
             
-            this%step_size = this%step_epochs_sec(this%intermediate_steps_index)
+            ! this%step_size = this%step_epochs_sec(this%intermediate_steps_index)
+            
+            ! Determine on which time step we are working
+            ! -- DO NOT TOUCH --
+            ! -- The new indexing-loop implementation now processes cases where 
+            ! -- neighbouring array-elements contain the same epoch (due to overlapping TDMs). 
+            ! -- Previously, those situations led to wrong in-array indexing and infinite 
+            ! -- looping, exhausting the allocated memory. 
+            do i_index = this%last_index, size(this%step_epochs_sec)
+                this%cumulated_time = this%cumulated_time + this%step_epochs_sec(i_index)
+                if (this%cumulated_time > current_time .or. i_index <= this%last_index) then
+                    this%last_index = i_index
+                    if (i_index < size(this%step_epochs_sec)) then
+                        this%last_index = i_index + 1
+                    end if
+                    exit
+                end if
+            end do
+            ! Extract the step size
+            this%step_size = this%step_epochs_sec(this%last_index)
 
-            ! cumulated_steps = 0.d0
-            ! ! Determine on which time step we are working
-            ! do i_index = 1, size(this%step_epochs_sec)
-            !     cumulated_steps = cumulated_steps + this%step_epochs_sec(i_index)
-            !     if (cumulated_steps > current_time) then
-            !         next_i_index = i_index
-            !         if (i_index < size(this%step_epochs_sec)) then
-            !             next_i_index = i_index + 1
-            !         end if
-            !         exit
-            !     end if
-            ! end do
-            ! ! Extract the step size
-            ! this%step_size = this%step_epochs_sec(next_i_index)
         end if
 
         ! for the covariance step, it can depend on the integration method. For example, the RK4 method requires
@@ -240,6 +250,10 @@ contains
         ! save the value for later reference (e.g. by has_finished_step)
         this%next_step = step
 
+        ! write(cmess,'(a)') 'this%step_size  = '//toString(this%step_size)//', this%next_step '//toString(this%next_step)
+        ! call message(cmess, LOG_AND_STDOUT)        
+        ! call message("request epoch: "//toString(this%next_step)//" this%last_index: "//toString(this%last_index), LOG_AND_STDOUT)
+        
         return
     end function
 
@@ -478,13 +492,13 @@ contains
             if((current_time - this%next_step) < epsilon(1.0d0)) hfs = .true.
         end if
         
-        if (this%intermediate_steps_flag .and. hfs) then 
-            if (this%intermediate_steps_index < size(this%step_epochs_sec)) then
-                this%intermediate_steps_index = this%intermediate_steps_index + 1
-            else 
-                this%intermediate_steps_index = size(this%step_epochs_sec)
-            end if
-        end if
+        ! if (this%intermediate_steps_flag .and. hfs) then 
+        !     if (this%intermediate_steps_index < size(this%step_epochs_sec)) then
+        !         this%intermediate_steps_index = this%intermediate_steps_index + 1
+        !     else 
+        !         this%intermediate_steps_index = size(this%step_epochs_sec)
+        !     end if
+        ! end if
 
         return
     end function

--- a/src/neptuneClock.f90
+++ b/src/neptuneClock.f90
@@ -42,6 +42,7 @@ module neptuneClock
         logical  :: cov_propagation_flag                                        !< is .true. when covariance matrix is propagated
         real(dp),dimension(:),allocatable  :: step_epochs_sec                   !< intermediate epochs (in seconds)
         logical  :: intermediate_steps_flag                                     !< is .true. when intermediate steps are to be take (requested by user)
+        integer  :: intermediate_steps_index                                    !  keeps track of in-array index whilst in intermediate mode
 
     contains
         procedure :: init_counter
@@ -98,6 +99,7 @@ contains
         constructor_time%flag_cov_update                = .false.               !< is .true. during covariance matrix update/integration steps
         constructor_time%flag_cov_save                  = .false.               !< is .true. when an intermediate step for the covariance needs to be saved (like for RK4)
         constructor_time%intermediate_steps_flag        = .false.
+        constructor_time%intermediate_steps_index       = 1
 
         !=====================================================
         !
@@ -147,20 +149,23 @@ contains
 
         ! When we are in intermediate steps mode we update the step_size with every request
         if (this%intermediate_steps_flag) then
-            cumulated_steps = 0.d0
-            ! Determine on which time step we are working
-            do i_index = 1, size(this%step_epochs_sec)
-                cumulated_steps = cumulated_steps + this%step_epochs_sec(i_index)
-                if (cumulated_steps > current_time) then
-                    next_i_index = i_index
-                    if (i_index < size(this%step_epochs_sec)) then
-                        next_i_index = i_index + 1
-                    end if
-                    exit
-                end if
-            end do
-            ! Extract the step size
-            this%step_size = this%step_epochs_sec(next_i_index)
+            
+            this%step_size = this%step_epochs_sec(this%intermediate_steps_index)
+
+            ! cumulated_steps = 0.d0
+            ! ! Determine on which time step we are working
+            ! do i_index = 1, size(this%step_epochs_sec)
+            !     cumulated_steps = cumulated_steps + this%step_epochs_sec(i_index)
+            !     if (cumulated_steps > current_time) then
+            !         next_i_index = i_index
+            !         if (i_index < size(this%step_epochs_sec)) then
+            !             next_i_index = i_index + 1
+            !         end if
+            !         exit
+            !     end if
+            ! end do
+            ! ! Extract the step size
+            ! this%step_size = this%step_epochs_sec(next_i_index)
         end if
 
         ! for the covariance step, it can depend on the integration method. For example, the RK4 method requires
@@ -452,17 +457,35 @@ contains
     !!  @anchor    has_finished_step
     !
     ! --------------------------------------------------------------------
-    pure function has_finished_step(this, current_time) result(hfs)
-        Class(Clock_class), intent(in) :: this
-        real(dp),     intent(in) :: current_time
-        logical :: hfs
+    function has_finished_step(this, current_time) result(hfs)
+        ! use slam_strings,       only: toString
+        ! use slam_io,            only: LOG_AND_STDOUT, message
+        Class(Clock_class)            :: this
+        real(dp),     intent(in)      :: current_time
+        logical                       :: hfs
+        character(len=255)            :: cmess
+        real(dp)                      :: diff 
 
+        ! diff = abs(this%next_step - current_time)
+        ! write(cmess, '(a, D15.3, a)') 'diff_nextStep = ', diff, toString((this%next_step - current_time) < epsilon(1.0d0))
+        ! call message(cmess, LOG_AND_STDOUT)
+        
         hfs = .false.
+        
         if(this%forward) then
             if((this%next_step - current_time) < epsilon(1.0d0)) hfs = .true.
         else
             if((current_time - this%next_step) < epsilon(1.0d0)) hfs = .true.
         end if
+        
+        if (this%intermediate_steps_flag .and. hfs) then 
+            if (this%intermediate_steps_index < size(this%step_epochs_sec)) then
+                this%intermediate_steps_index = this%intermediate_steps_index + 1
+            else 
+                this%intermediate_steps_index = size(this%step_epochs_sec)
+            end if
+        end if
+
         return
     end function
 


### PR DESCRIPTION
Update NeptuneClock.f90 to have its internal arrays handle neighbouring entries of the same epochs gracefully.
Changes apply when in intermediate-mode in ::get_next_step, 