### PR TITLE
Jwy/integer step

### DIFF
--- a/src/neptuneClass.f90
+++ b/src/neptuneClass.f90
@@ -125,7 +125,8 @@ module neptuneClass
         ! Variables
         !
         !-----------------------------------------------------------------------
-        integer                         :: output_step                          ! output time step in seconds, 5 mins as default
+        !integer                         :: output_step                          ! output time step in seconds, 5 mins as default
+        real(dp)                        :: output_step                          ! output time step that can touch double precision
         integer, public                 :: input_type_cov                       ! input type for covariance matrix
 
         logical, dimension(2), public   :: flag_init_tolerances                 ! rel. and abs. tolerance initialization for numerical integration
@@ -286,7 +287,7 @@ contains
         constructor%reduction = Reduction_type()
         constructor%correlation_model = Correlation_class()
 
-        constructor%output_step    = 300                                        ! output time step in seconds, 5 mins as default
+        constructor%output_step    = 300.0                                        ! output time step in seconds, 5 mins as default
         constructor%input_type_cov = INPUT_UNDEFINED                            ! input type for covariance matrix
 
         constructor%flag_init_tolerances = (/.false.,.false./)                  ! rel. and abs. tolerance initialization for numerical integration
@@ -463,7 +464,7 @@ contains
         ! INTEGER parameters
         call this%set_input(parName=C_GEOPOTENTIAL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_SAT_PROPERTIES, valType='integer', initFlag=.true.)
-        call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
+        !call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_PAR_INT_COV_METHOD, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_GEO_MODEL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_AP_FORECAST, valType='integer', initFlag=.true.)
@@ -483,6 +484,7 @@ contains
         call this%set_input(parName=C_PAR_INT_COV_STEP, valType='double', initFlag=.true.)
         call this%set_input(parName=C_PAR_EARTH_RADIUS, valType='double', initFlag=.true.)
         call this%set_input(parName=C_OPT_SOL_FORECAST, valType='double', initFlag=.true.)
+        call this%set_input(parName=C_OUTPUT_STEP, valType='double', initFlag=.true.) ! this should be double for the fix 
 
         ! ON/OFF parameters (also set default values, if available)
         do i = 1, this%derivatives_model%get_neptune_perturbation_number()
@@ -1713,7 +1715,7 @@ contains
           ! CASE for INTEGER parameters
           !
           !------------------------
-          case(C_GEOPOTENTIAL,  C_OPT_SAT_PROPERTIES, C_OUTPUT_STEP,    C_PAR_INT_COV_METHOD, &
+          case(C_GEOPOTENTIAL,  C_OPT_SAT_PROPERTIES,   C_PAR_INT_COV_METHOD, & ! remove C_OUTPUT_STEP
                C_OPT_GEO_MODEL, C_OPT_AP_FORECAST,    C_OPT_STORE_DATA, C_COV_GEOPOTENTIAL,   &
                C_PAR_INT_METHOD, C_OPT_ATMOSPHERE_MODEL)
 
@@ -1761,12 +1763,6 @@ contains
                   call this%set_input(parName=C_OPT_STORE_DATA, val=val, set=.true.)
                   call this%setStep(itemp)
 
-                !** Output
-                case(C_OUTPUT_STEP)
-                  call this%set_input(parName=C_OUTPUT_STEP, val=val, set=.true.)
-                  call this%output%write_to_output(C_OUTPUT_STEP, itemp)
-                  this%output_step = itemp
-
                 !** state vector integration method
                 case(C_PAR_INT_METHOD)
                   call this%set_input(parName=C_PAR_INT_METHOD, val=val, set=.true.)
@@ -1791,7 +1787,7 @@ contains
           ! CASE for REAL parameters
           !
           !-------------------------
-          case(C_PAR_MASS, C_PAR_CROSS_SECTION, C_PAR_CDRAG,         &
+          case(C_PAR_MASS, C_PAR_CROSS_SECTION, C_PAR_CDRAG, C_OUTPUT_STEP,         & ! add C_OUTPUT_STEP
                C_PAR_CREFL, C_PAR_REENTRY, C_PAR_INT_RELEPS, C_PAR_INT_ABSEPS, &
                C_PAR_INT_COV_STEP, C_PAR_EARTH_RADIUS, &
                C_OPT_SOL_FORECAST)
@@ -1859,6 +1855,12 @@ contains
                 case(C_OPT_SOL_FORECAST)
                   call this%set_input(parName=C_OPT_SOL_FORECAST, val=val, set=.true.)
                   call this%atmosphere_model%setSolarFluxForecast(dtemp)
+
+                !** Output
+                case(C_OUTPUT_STEP)
+                  call this%set_input(parName=C_OUTPUT_STEP, val=val, set=.true.)
+                  call this%output%write_to_output(C_OUTPUT_STEP, itemp)
+                  this%output_step = dtemp
 
               end select
 
@@ -2736,7 +2738,7 @@ contains
         ! INTEGER parameters
         call this%set_input(parName=C_GEOPOTENTIAL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_SAT_PROPERTIES, valType='integer', initFlag=.true.)
-        call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
+        ! call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_PAR_INT_COV_METHOD, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_GEO_MODEL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_AP_FORECAST, valType='integer', initFlag=.true.)
@@ -2756,6 +2758,8 @@ contains
         call this%set_input(parName=C_PAR_INT_COV_STEP, valType='double', initFlag=.true.)
         call this%set_input(parName=C_PAR_EARTH_RADIUS, valType='double', initFlag=.true.)
         call this%set_input(parName=C_OPT_SOL_FORECAST, valType='double', initFlag=.true.)
+        call this%set_input(parName=C_OUTPUT_STEP, valType='double', initFlag=.true.) ! this should be double 
+
 
         ! ON/OFF parameters (also set default values, if available)
         do i = 1, this%derivatives_model%get_neptune_perturbation_number()

--- a/src/neptuneClass.f90
+++ b/src/neptuneClass.f90
@@ -125,8 +125,6 @@ module neptuneClass
         ! Variables
         !
         !-----------------------------------------------------------------------
-        !integer                         :: output_step                          ! output time step in seconds, 5 mins as default
-        real(dp)                        :: output_step                          ! output time step that can touch double precision
         integer, public                 :: input_type_cov                       ! input type for covariance matrix
 
         logical, dimension(2), public   :: flag_init_tolerances                 ! rel. and abs. tolerance initialization for numerical integration
@@ -146,6 +144,7 @@ module neptuneClass
         type(covariance_t)              :: initial_covariance                   !< initial covariance matrix written to output
 
         real(dp)                        :: progress_step                        !< step threshold for progress output to file
+        real(dp)                        :: output_step                          ! output time step that can touch double precision
 
         !=======================================================================
         !
@@ -464,7 +463,6 @@ contains
         ! INTEGER parameters
         call this%set_input(parName=C_GEOPOTENTIAL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_SAT_PROPERTIES, valType='integer', initFlag=.true.)
-        !call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_PAR_INT_COV_METHOD, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_GEO_MODEL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_AP_FORECAST, valType='integer', initFlag=.true.)
@@ -1715,7 +1713,7 @@ contains
           ! CASE for INTEGER parameters
           !
           !------------------------
-          case(C_GEOPOTENTIAL,  C_OPT_SAT_PROPERTIES,   C_PAR_INT_COV_METHOD, & ! remove C_OUTPUT_STEP
+          case(C_GEOPOTENTIAL,  C_OPT_SAT_PROPERTIES,   C_PAR_INT_COV_METHOD, & 
                C_OPT_GEO_MODEL, C_OPT_AP_FORECAST,    C_OPT_STORE_DATA, C_COV_GEOPOTENTIAL,   &
                C_PAR_INT_METHOD, C_OPT_ATMOSPHERE_MODEL)
 
@@ -1787,7 +1785,7 @@ contains
           ! CASE for REAL parameters
           !
           !-------------------------
-          case(C_PAR_MASS, C_PAR_CROSS_SECTION, C_PAR_CDRAG, C_OUTPUT_STEP,         & ! add C_OUTPUT_STEP
+          case(C_PAR_MASS, C_PAR_CROSS_SECTION, C_PAR_CDRAG, C_OUTPUT_STEP,    & 
                C_PAR_CREFL, C_PAR_REENTRY, C_PAR_INT_RELEPS, C_PAR_INT_ABSEPS, &
                C_PAR_INT_COV_STEP, C_PAR_EARTH_RADIUS, &
                C_OPT_SOL_FORECAST)
@@ -2738,7 +2736,6 @@ contains
         ! INTEGER parameters
         call this%set_input(parName=C_GEOPOTENTIAL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_SAT_PROPERTIES, valType='integer', initFlag=.true.)
-        ! call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_PAR_INT_COV_METHOD, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_GEO_MODEL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_AP_FORECAST, valType='integer', initFlag=.true.)

--- a/src/rdinp.f90
+++ b/src/rdinp.f90
@@ -125,10 +125,6 @@ subroutine rdinp(                &
   integer :: input_type_cov
   integer :: b_left, b_right    ! indices for version string parsing
 
-  real(dp)    :: dch_inp            ! input file channel 
-  real(dp)    :: dtemp              ! temporary
-  real(dp)    :: derr               ! error flag
-
   integer, dimension(100) :: distinctHarmonics
 
   real(dp), dimension(3) :: dtmp3
@@ -675,7 +671,7 @@ subroutine rdinp(                &
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp
-  derr =  neptune%setNeptuneVar("OUTPUT_STEP", ctemp)
+  ierr =  neptune%setNeptuneVar("OUTPUT_STEP", ctemp)
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp

--- a/src/rdinp.f90
+++ b/src/rdinp.f90
@@ -125,6 +125,10 @@ subroutine rdinp(                &
   integer :: input_type_cov
   integer :: b_left, b_right    ! indices for version string parsing
 
+  real(dp)    :: dch_inp            ! input file channel 
+  real(dp)    :: dtemp              ! temporary
+  real(dp)    :: derr               ! error flag
+
   integer, dimension(100) :: distinctHarmonics
 
   real(dp), dimension(3) :: dtmp3
@@ -671,11 +675,11 @@ subroutine rdinp(                &
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp
-  ierr =  neptune%setNeptuneVar("OUTPUT_STEP", ctemp)
+  derr =  neptune%setNeptuneVar("OUTPUT_STEP", ctemp)
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp
-  ierr =  neptune%setNeptuneVar("OPT_STORE_DATA", ctemp)
+  derr =  neptune%setNeptuneVar("OPT_STORE_DATA", ctemp)
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) itemp

--- a/src/rdinp.f90
+++ b/src/rdinp.f90
@@ -679,7 +679,7 @@ subroutine rdinp(                &
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp
-  derr =  neptune%setNeptuneVar("OPT_STORE_DATA", ctemp)
+  ierr =  neptune%setNeptuneVar("OPT_STORE_DATA", ctemp)
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) itemp

--- a/work/input/neptune.inp
+++ b/work/input/neptune.inp
@@ -200,7 +200,7 @@
 #
 #   Output time step (in seconds)
 #
-  60
+  2.5
 #
 #   Time step for ephemerides in internal array (available via 'getNeptuneData' API)
 #   (in seconds - IF not '0' then output time step (above) will be overwritten by this

--- a/work/input/neptune.inp
+++ b/work/input/neptune.inp
@@ -200,7 +200,7 @@
 #
 #   Output time step (in seconds)
 #
-  2.5
+  60.0
 #
 #   Time step for ephemerides in internal array (available via 'getNeptuneData' API)
 #   (in seconds - IF not '0' then output time step (above) will be overwritten by this


### PR DESCRIPTION
In this part, I look into the integer limitation for the time step. The following are the changes:

1. neptune.inp
time step change to 2.5 to check if it works out. 

2. rdinp.f90 
add double precision function into the file, and make output_step double precision  

3. neptuneClass.f90
move all of the output_step function from integer catagory to double precision catagory 

I did some compiling test and it should work. (hopefully) 