### PR TITLE
Ifort fix

### DIFF
--- a/tests/test_radiation.pf
+++ b/tests/test_radiation.pf
@@ -15,13 +15,13 @@
 !------------------------------------------------------------------------
 module test_radiation
 use funit
-use radiation
+use radiation,      only: Radiation_class
 use slam_reduction_class, only: Reduction_type
 use slam_math
 use slam_error_handling
 use satellite
-use solarsystem
-use Neptuneclass
+use solarsystem,    only: Solarsystem_class, initSolarSystem
+use Neptuneclass,   only: Neptune_class, time_t
 
 implicit none
 

--- a/tests/test_solarsystem.pf
+++ b/tests/test_solarsystem.pf
@@ -15,7 +15,7 @@
 !------------------------------------------------------------------------
 module test_solarsystem
     use funit
-    use solarsystem
+    use solarsystem,    only: Solarsystem_class
     use neptuneClass
     
     implicit none

--- a/tests/test_thirdbody.pf
+++ b/tests/test_thirdbody.pf
@@ -19,8 +19,8 @@ use thirdbody
 use slam_reduction_class, only: Reduction_type
 use slam_math
 use slam_error_handling
-use solarsystem
-use neptuneClass
+use solarsystem,    only: Solarsystem_class, initSolarSystem
+use neptuneClass,   only: time_t
 implicit none
 
 contains


### PR DESCRIPTION
Within some of the test modules, multiple procedures and types have been included in an ambiguous (duplicated) way -> compiler issues with ifort. That has been fixed by specifying what parts of a module to include exactly. With the changes ifort compiles.