### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Intel")
     # Reason: some dynamically allocated arrays are replicated when OpenMP is used with the neptuneClass.
     # The (small) stack is used for the replication of the arrays. The flag moves arrays from the stack to the heap.
 	#set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -heap-arrays 32768")
-	set (CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0 -fpp -DDBLE -g -fno-omit-frame-pointer -traceback -check bounds -check output-conversion -check format -check pointers -check uninit -ftrapuv -assume realloc_lhs -fstack-protector -assume protect_parens")
+	set (CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0 -fpp -DDBLE -g -fno-omit-frame-pointer -traceback -check bounds -check output-conversion -check format -check pointers -ftrapuv -assume realloc_lhs -fstack-protector -assume protect_parens")
 	set (CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -O3 -fpp -DDBLE")
 elseif ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "Flang")
     set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Mpreprocess")


### PR DESCRIPTION
The intel debug compiler flag "-check uninit" in combination with the current ifx compiler seems to result in false positives leading to inability to successfully build a debug version. The check shall therefore be removed from this cmakelists file.