### PR TITLE
dla / Use float as output step. Change time output to include microseconds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
 
 endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
+set(CMAKE_FIND_LIBRARY_SUFFIXES .dll ${CMAKE_FIND_LIBRARY_SUFFIXES})
+
 if ("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
 	set (CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS} -O0 -cpp -DDBLE -g -fbounds-check -fbacktrace -ffree-line-length-none -finit-local-zero  -Wall")
     set (CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS} -O3 -DDBLE -ffree-line-length-none -cpp")

--- a/README.md
+++ b/README.md
@@ -17,17 +17,30 @@ The propagator is written in Fortran-2008 and HPC ready by enabling OpenMP.
 The software can be compiled on 
 * Linux, 
 * macOS and 
-* Windows (using the Windows Subsystem for Linux on Windows 10, cygwin or MinGW)
+* Windows (MSYS2)
 
 To build NEPTUNE you will need:
 * a fortran compiler (e.g. gfortran >= 8.0 or ifort > 19.0)
 * cmake >= 3.12
 * the [Orbital Propagation Interface (OPI-2015)](https://github.com/ILR/OPI) (retrieved automatically)
 * the support library [libslam](https://github.com/IRAS/libslam) (retrieved automatically)
+* the testing framework [pFUnit](https://github.com/Goddard-Fortran-Ecosystem/pFUnit) (retrieved automatically)
 * doxygen (only for the source code documentation)
 * graphviz (only for the source code documentation)
 * latex (only for editing the technical documentation)
   * On Ubuntu 18.04 LTS this works: `apt install texlive texlive-lang-german texlive-latex-extra texlive-tubs texlive-science`
+
+For MSYS2 you need to install the newest MSYS2 version and install in the MINGW64 environment (important to use this shell in particular):
+* mingw-w64-x86_64-gcc
+* mingw-w64-x86_64-gcc-fortran
+* mingw-w64-x86_64-cmake
+* mingw-w64-x86_64-ninja
+* mingw-w64-x86_64-toolchain
+* base-devel
+
+To install, use `pacman -S mypackagename`.
+
+Note that installing `mingw-w64-x86_64-python3` might lead to issues building pFUnit.
 
 To get started execute the build script:
 ```

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,8 @@
 # Define how to build the libraries and executables:
 BUILD_TYPE=Debug
 Fortran_COMPILER=gfortran
+GENERATOR="Unix Makefiles"
+ENABLE_OPI_SUPPORT=OFF
 LIBSUFFIX="so"
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
   LIBSUFFIX="so"
@@ -12,6 +14,9 @@ elif [[ "$OSTYPE" == "CYGWIN"* ]]; then
   LIBSUFFIX="dll"
 elif [[ "$OSTYPE" == "MINGW"* ]]; then
   LIBSUFFIX="dll"
+elif [[ "$OSTYPE" == "msys"* ]]; then
+  LIBSUFFIX="dll"
+  GENERATOR="MSYS Makefiles"
 fi
 git submodule update --init --recursive
 ################################################################################
@@ -19,25 +24,28 @@ git submodule update --init --recursive
 #                                  Build OPI                                   #
 #                                                                              #
 ################################################################################
-# Build OPI
-cd OPI || exit || exit
-# Create the build directory if it does not exist
-if [[ ! -d "build" ]]; then
-  mkdir build
-else
-  rm -rf build/*
+if [[ "$ENABLE_OPI_SUPPORT" == "ON" ]]; then
+  # Build OPI
+  cd OPI || exit || exit
+  # Create the build directory if it does not exist
+  if [[ ! -d "build" ]]; then
+    mkdir build
+  else
+    rm -rf build/*
+  fi
+  cd build || exit || exit
+  echo "Updating cmake"
+  cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=../ -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_CXX11=ON -DENABLE_CL_SUPPORT=OFF -DENABLE_CUDA_SUPPORT=OFF -DENABLE_PYTHON=OFF -G "$GENERATOR" ../
+  echo "Building OPI"
+  cmake --build .
+  cmake --install .
+  if [[ $? -ne 0 ]]; then
+    echo "Could not build OPI. Exiting."
+    exit $?
+  fi
+  echo "Leaving OPI"
+  cd ../../
 fi
-cd build || exit || exit
-echo "Updating cmake"
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=../ -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_CXX11=ON -DENABLE_CL_SUPPORT=OFF -DENABLE_CUDA_SUPPORT=OFF -DENABLE_PYTHON=OFF ../
-echo "Building OPI"
-make install
-if [[ $? -ne 0 ]]; then
-  echo "Could not build OPI. Exiting."
-  exit $?
-fi
-echo "Leaving OPI"
-cd ../../
 ################################################################################
 #                                                                              #
 #                                Build libslam                                 #
@@ -53,15 +61,25 @@ else
 fi
 cd build || exit || exit
 echo "Updating cmake"
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_OpenMP_SUPPORT=OFF -DENABLE_POSTGRESQL_SUPPORT=OFF ../
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_OpenMP_SUPPORT=OFF -DENABLE_POSTGRESQL_SUPPORT=OFF -G "$GENERATOR" ../
 echo "Building libslam"
-make install
+cmake --build .
+cmake --install .
 if [[ $? -ne 0 ]]; then
     echo "Could not build libslam. Exiting."
     exit $?
 fi
 echo "Manually preparing 'lib' and 'include' directories"
 cd ../
+# Delete the include and lib folders when they exist, 
+# as linking on windows will create directories which 
+# leads to errors on the second run of the script
+if [[ ! -d "include" ]]; then
+  rm -rf include
+fi
+if [[ ! -d "lib" ]]; then
+  rm -rf lib
+fi
 ln -sf build/include include
 ln -sf build/lib lib
 echo "Leaving libslam"
@@ -81,10 +99,10 @@ fi
 cd build || exit
 echo "Updating cmake"
 export FC=$Fortran_COMPILER
-cmake -DSKIP_MPI=yes ../
+cmake -DSKIP_MPI=yes -G "$GENERATOR" ../
 echo "Building pFUnit"
-make
-make install
+cmake --build .
+cmake --install .
 cd ../
 echo "Leaving pFUnit"
 cd ../
@@ -97,11 +115,13 @@ cd ../
 if [[ ! -d "lib" ]]; then
   mkdir lib
 fi
-# Create the links to libraries needed by CAMP
+# Create the links to libraries needed by NEPTUNE
 cd lib || exit || exit
 ln -sf ../libslam/lib/libslam-Fortran.$LIBSUFFIX .
-ln -sf ../OPI/lib/libOPI-Fortran.$LIBSUFFIX .
-ln -sf ../OPI/lib/libOPI.$LIBSUFFIX .
+if [[ "$ENABLE_OPI_SUPPORT" == "ON" ]]; then
+  ln -sf ../OPI/lib/libOPI-Fortran.$LIBSUFFIX .
+  ln -sf ../OPI/lib/libOPI.$LIBSUFFIX .
+fi
 cd ..
 # Create the include directory if it does not exist
 if [[ ! -d "include" ]]; then
@@ -110,7 +130,9 @@ fi
 # Create the links to includes needed by NEPTUNE
 cd include || exit || exit
 ln -sf ../libslam/include/SLAM .
-ln -sf ../OPI/include/OPI .
+if [[ "$ENABLE_OPI_SUPPORT" == "ON" ]]; then
+  ln -sf ../OPI/include/OPI .
+fi
 cd ..
 # Create the build directory if it does not exist
 if [[ ! -d "build" ]]; then
@@ -121,15 +143,24 @@ fi
 cd build || exit || exit
 echo "Updating cmake"
 export PFUNIT_DIR=..//pFUnit/build/installed
-cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_OPI_SUPPORT=ON -DSKIP_MSIS_2=ON ../
+cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_Fortran_COMPILER=$Fortran_COMPILER -DENABLE_OPI_SUPPORT=$ENABLE_OPI_SUPPORT -DSKIP_MSIS_2=ON -G "$GENERATOR" ../
 echo "Building NEPTUNE"
-make install
+cmake --build .
+cmake --install .
 if [[ $? -ne 0 ]]; then
     echo "Could not build NEPTUNE. Exiting."
     exit $?
 fi
 echo "Leaving NEPTUNE"
 cd ../work || exit || exit
-ln -sf ../bin/neptune-sa . .
+if [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "MINGW"* ]]; then
+  ln -sf ../bin/neptune-sa.exe . || exit || exit
+  ln -sf ../bin/libneptune.dll . || exit || exit
+  ln -sf ../lib/libneptune.dll.a . || exit || exit
+  ln -sf ../libslam/lib/libslam-Fortran.dll . || exit || exit
+  ln -sf ../libslam/lib/libslam-Fortran.dll.a . || exit || exit
+else 
+  ln -sf ../bin/neptune-sa . || exit || exit
+fi
 cd ..
 echo "Done"

--- a/src/neptuneClass.f90
+++ b/src/neptuneClass.f90
@@ -125,8 +125,6 @@ module neptuneClass
         ! Variables
         !
         !-----------------------------------------------------------------------
-        !integer                         :: output_step                          ! output time step in seconds, 5 mins as default
-        real(dp)                        :: output_step                          ! output time step that can touch double precision
         integer, public                 :: input_type_cov                       ! input type for covariance matrix
 
         logical, dimension(2), public   :: flag_init_tolerances                 ! rel. and abs. tolerance initialization for numerical integration
@@ -146,6 +144,7 @@ module neptuneClass
         type(covariance_t)              :: initial_covariance                   !< initial covariance matrix written to output
 
         real(dp)                        :: progress_step                        !< step threshold for progress output to file
+        real(dp)                        :: output_step                          ! output time step that can touch double precision
 
         !=======================================================================
         !
@@ -466,7 +465,6 @@ contains
         ! INTEGER parameters
         call this%set_input(parName=C_GEOPOTENTIAL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_SAT_PROPERTIES, valType='integer', initFlag=.true.)
-        !call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_PAR_INT_COV_METHOD, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_GEO_MODEL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_AP_FORECAST, valType='integer', initFlag=.true.)
@@ -1717,7 +1715,7 @@ contains
           ! CASE for INTEGER parameters
           !
           !------------------------
-          case(C_GEOPOTENTIAL,  C_OPT_SAT_PROPERTIES,   C_PAR_INT_COV_METHOD, & ! remove C_OUTPUT_STEP
+          case(C_GEOPOTENTIAL,  C_OPT_SAT_PROPERTIES,   C_PAR_INT_COV_METHOD, & 
                C_OPT_GEO_MODEL, C_OPT_AP_FORECAST,    C_OPT_STORE_DATA, C_COV_GEOPOTENTIAL,   &
                C_PAR_INT_METHOD, C_OPT_ATMOSPHERE_MODEL)
 
@@ -1789,7 +1787,7 @@ contains
           ! CASE for REAL parameters
           !
           !-------------------------
-          case(C_PAR_MASS, C_PAR_CROSS_SECTION, C_PAR_CDRAG, C_OUTPUT_STEP,         & ! add C_OUTPUT_STEP
+          case(C_PAR_MASS, C_PAR_CROSS_SECTION, C_PAR_CDRAG, C_OUTPUT_STEP,    & 
                C_PAR_CREFL, C_PAR_REENTRY, C_PAR_INT_RELEPS, C_PAR_INT_ABSEPS, &
                C_PAR_INT_COV_STEP, C_PAR_EARTH_RADIUS, &
                C_OPT_SOL_FORECAST)
@@ -2807,7 +2805,6 @@ contains
         ! INTEGER parameters
         call this%set_input(parName=C_GEOPOTENTIAL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_SAT_PROPERTIES, valType='integer', initFlag=.true.)
-        ! call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_PAR_INT_COV_METHOD, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_GEO_MODEL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_AP_FORECAST, valType='integer', initFlag=.true.)

--- a/src/neptuneClass.f90
+++ b/src/neptuneClass.f90
@@ -125,7 +125,8 @@ module neptuneClass
         ! Variables
         !
         !-----------------------------------------------------------------------
-        integer                         :: output_step                          ! output time step in seconds, 5 mins as default
+        !integer                         :: output_step                          ! output time step in seconds, 5 mins as default
+        real(dp)                        :: output_step                          ! output time step that can touch double precision
         integer, public                 :: input_type_cov                       ! input type for covariance matrix
 
         logical, dimension(2), public   :: flag_init_tolerances                 ! rel. and abs. tolerance initialization for numerical integration
@@ -288,7 +289,7 @@ contains
         constructor%reduction = Reduction_type()
         constructor%correlation_model = Correlation_class()
 
-        constructor%output_step    = 300                                        ! output time step in seconds, 5 mins as default
+        constructor%output_step    = 300.0                                        ! output time step in seconds, 5 mins as default
         constructor%input_type_cov = INPUT_UNDEFINED                            ! input type for covariance matrix
 
         constructor%flag_init_tolerances = (/.false.,.false./)                  ! rel. and abs. tolerance initialization for numerical integration
@@ -465,7 +466,7 @@ contains
         ! INTEGER parameters
         call this%set_input(parName=C_GEOPOTENTIAL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_SAT_PROPERTIES, valType='integer', initFlag=.true.)
-        call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
+        !call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_PAR_INT_COV_METHOD, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_GEO_MODEL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_AP_FORECAST, valType='integer', initFlag=.true.)
@@ -485,6 +486,7 @@ contains
         call this%set_input(parName=C_PAR_INT_COV_STEP, valType='double', initFlag=.true.)
         call this%set_input(parName=C_PAR_EARTH_RADIUS, valType='double', initFlag=.true.)
         call this%set_input(parName=C_OPT_SOL_FORECAST, valType='double', initFlag=.true.)
+        call this%set_input(parName=C_OUTPUT_STEP, valType='double', initFlag=.true.) ! this should be double for the fix 
 
         ! ON/OFF parameters (also set default values, if available)
         do i = 1, this%derivatives_model%get_neptune_perturbation_number()
@@ -1715,7 +1717,7 @@ contains
           ! CASE for INTEGER parameters
           !
           !------------------------
-          case(C_GEOPOTENTIAL,  C_OPT_SAT_PROPERTIES, C_OUTPUT_STEP,    C_PAR_INT_COV_METHOD, &
+          case(C_GEOPOTENTIAL,  C_OPT_SAT_PROPERTIES,   C_PAR_INT_COV_METHOD, & ! remove C_OUTPUT_STEP
                C_OPT_GEO_MODEL, C_OPT_AP_FORECAST,    C_OPT_STORE_DATA, C_COV_GEOPOTENTIAL,   &
                C_PAR_INT_METHOD, C_OPT_ATMOSPHERE_MODEL)
 
@@ -1763,12 +1765,6 @@ contains
                   call this%set_input(parName=C_OPT_STORE_DATA, val=val, set=.true.)
                   call this%setStep(itemp)
 
-                !** Output
-                case(C_OUTPUT_STEP)
-                  call this%set_input(parName=C_OUTPUT_STEP, val=val, set=.true.)
-                  call this%output%write_to_output(C_OUTPUT_STEP, itemp)
-                  this%output_step = itemp
-
                 !** state vector integration method
                 case(C_PAR_INT_METHOD)
                   call this%set_input(parName=C_PAR_INT_METHOD, val=val, set=.true.)
@@ -1793,7 +1789,7 @@ contains
           ! CASE for REAL parameters
           !
           !-------------------------
-          case(C_PAR_MASS, C_PAR_CROSS_SECTION, C_PAR_CDRAG,         &
+          case(C_PAR_MASS, C_PAR_CROSS_SECTION, C_PAR_CDRAG, C_OUTPUT_STEP,         & ! add C_OUTPUT_STEP
                C_PAR_CREFL, C_PAR_REENTRY, C_PAR_INT_RELEPS, C_PAR_INT_ABSEPS, &
                C_PAR_INT_COV_STEP, C_PAR_EARTH_RADIUS, &
                C_OPT_SOL_FORECAST)
@@ -1861,6 +1857,12 @@ contains
                 case(C_OPT_SOL_FORECAST)
                   call this%set_input(parName=C_OPT_SOL_FORECAST, val=val, set=.true.)
                   call this%atmosphere_model%setSolarFluxForecast(dtemp)
+
+                !** Output
+                case(C_OUTPUT_STEP)
+                  call this%set_input(parName=C_OUTPUT_STEP, val=val, set=.true.)
+                  call this%output%write_to_output(C_OUTPUT_STEP, itemp)
+                  this%output_step = dtemp
 
               end select
 
@@ -2805,7 +2807,7 @@ contains
         ! INTEGER parameters
         call this%set_input(parName=C_GEOPOTENTIAL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_SAT_PROPERTIES, valType='integer', initFlag=.true.)
-        call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
+        ! call this%set_input(parName=C_OUTPUT_STEP, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_PAR_INT_COV_METHOD, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_GEO_MODEL, valType='integer', initFlag=.true.)
         call this%set_input(parName=C_OPT_AP_FORECAST, valType='integer', initFlag=.true.)
@@ -2825,6 +2827,8 @@ contains
         call this%set_input(parName=C_PAR_INT_COV_STEP, valType='double', initFlag=.true.)
         call this%set_input(parName=C_PAR_EARTH_RADIUS, valType='double', initFlag=.true.)
         call this%set_input(parName=C_OPT_SOL_FORECAST, valType='double', initFlag=.true.)
+        call this%set_input(parName=C_OUTPUT_STEP, valType='double', initFlag=.true.) ! this should be double 
+
 
         ! ON/OFF parameters (also set default values, if available)
         do i = 1, this%derivatives_model%get_neptune_perturbation_number()

--- a/src/neptuneOutput.f90
+++ b/src/neptuneOutput.f90
@@ -1142,7 +1142,6 @@ contains
 
     character(len=*), parameter :: csubid = "output"
     integer                 :: i,j,k                                            ! loop counter
-    integer                 :: isec                                             ! seconds
     integer                 :: orbit_type                                       ! orbit type
 
     logical                 :: flag_cov_uvw                                     ! indicating that covariance matrix already transformed to UVW frame
@@ -1154,6 +1153,7 @@ contains
     real(dp)                 :: alt                                             ! current altitude (km)
     real(dp)                 :: crossSection                                    ! cross-section / m**2
     real(dp)                 :: fracday                                         ! fraction of day (0<=fracday<1)
+    real(dp)                 :: dsec                                            ! second 
     real(dp), dimension(6,6) :: jacobi                                          ! jacobian matrix to convert covariance matrix from ECI to UVW system
     real(dp)                 :: lat                                             ! current latitude (degrees)
     real(dp)                 :: lon                                             ! current longitude (degrees)
@@ -1178,7 +1178,7 @@ contains
     epoch%mjd = this%start_epoch%mjd + time_offset/86400.d0
 
     call mjd2gd(epoch%mjd,epoch%year,epoch%month,epoch%day,fracday)
-    call dayFraction2HMS(fracday,epoch%hour,epoch%minute,isec)
+    call dayFraction2HMS(fracday,epoch%hour,epoch%minute,dsec)
 
     do i = 1, size(this%output_arr)
 
@@ -1199,25 +1199,25 @@ contains
 
               case(ELLIPTICAL_INCLINED)
 
-                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                     kepler%sma, kepler%ecc, kepler%inc*rad2deg, kepler%raan*rad2deg,               &
                                     kepler%aop*rad2deg, kepler%tran*rad2deg, kepler%man*rad2deg
 
               case(CIRCULAR_INCLINED)
 
-                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                     kepler%sma, kepler%ecc, kepler%inc*rad2deg, kepler%raan*rad2deg,               &
                                     0.d0, kepler%arglat*rad2deg, kepler%man*rad2deg
 
               case(ELLIPTICAL_EQUATORIAL)
 
-                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                     kepler%sma, kepler%ecc, kepler%inc*rad2deg, 0.d0, kepler%lonper*rad2deg,       &
                                     kepler%tran*rad2deg, kepler%man*rad2deg
 
               case(CIRCULAR_EQUATORIAL)
 
-                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                     kepler%sma, kepler%ecc, kepler%inc*rad2deg, 0.d0, 0.d0, kepler%truelon*rad2deg, &
                                     kepler%man*rad2deg
 
@@ -1225,14 +1225,14 @@ contains
 
           case(OUTPUT_CSV)  !** cartesian state vs. time
 
-            write(this%output_arr(i)%file_unit,120)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd,   &
+            write(this%output_arr(i)%file_unit,120)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
                                   state_out%r, state_out%v
 
           case(OUTPUT_VAR_ECI)  !** variances (diagonal elements of covariance matrix) in ECI frame vs. time
 
             if(numint%getCovariancePropagationFlag()) then
 
-              write(this%output_arr(i)%file_unit,150)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd,   &
+              write(this%output_arr(i)%file_unit,150)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
                                     (covar_out%elem(j,j), j=1,6)
 
             end if
@@ -1251,7 +1251,7 @@ contains
 
               end if
 
-              write(this%output_arr(i)%file_unit,150)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd,   &
+              write(this%output_arr(i)%file_unit,150)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
                                     (covar_out_uvw%elem(j,j), j=1,6)
                                    ! (sqrt(max(0.d0,covar_out_uvw%elem(j,j)))*1.d3, j=1,6)
 
@@ -1261,7 +1261,7 @@ contains
 
             if(numint%getCovariancePropagationFlag()) then
 
-              write(this%output_arr(i)%file_unit,160)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd,   &
+              write(this%output_arr(i)%file_unit,160)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
                                     ((covar_out%elem(j,k), k=1,j-1), j=2,6)
 
             end if
@@ -1280,7 +1280,7 @@ contains
 
               end if
 
-              write(this%output_arr(i)%file_unit,160)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd,   &
+              write(this%output_arr(i)%file_unit,160)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
                                     ((covar_out_uvw%elem(j,k), k=1,j-1), j=2,6)
 
             end if
@@ -1313,7 +1313,7 @@ contains
             !** convert acceleration to UVW coordinates
             call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-            write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+            write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                  (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
           case(OUTPUT_ACG) !** acceleration due to geopotential vs. time
@@ -1348,7 +1348,7 @@ contains
             !** convert acceleration to UVW coordinates
             call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-            write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+            write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                  (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
           case(OUTPUT_ACD)
@@ -1383,7 +1383,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1404,7 +1404,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1425,7 +1425,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1448,7 +1448,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1471,7 +1471,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1503,7 +1503,7 @@ contains
 
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1535,7 +1535,7 @@ contains
 
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1556,7 +1556,7 @@ contains
 
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1585,7 +1585,7 @@ contains
               crossSection = satellite_model%getObjectCrossSection(solarsystem_model, reduction, epoch%mjd, state_out%r, v_rel)
               if(hasFailed()) return
 
-              write(this%output_arr(i)%file_unit,170)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,170)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
                                    rho, crossSection*1.d6, (v_rel(j), j=1,3)    ! '1.d6' for cross-section to convert to m**2
 
             end if
@@ -1624,7 +1624,7 @@ contains
 
             call getGeodeticLatLon(r_itrf, alt, lat, lon)
 
-            write(this%output_arr(i)%file_unit,140)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, isec, epoch%mjd, alt, lat*rad2deg, lon*rad2deg
+            write(this%output_arr(i)%file_unit,140)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, alt, lat*rad2deg, lon*rad2deg
 
         end select
 
@@ -1639,13 +1639,13 @@ contains
       call checkOut(csubid)
     end if
 
-110   format(4x,i4.4,2('-',i2.2),1x,i2.2,2(':',i2.2),5x,f16.9,2x,f12.5,2x,f10.8,5(1x,f12.6))
-120   format(4x,i4.4,2('-',i2.2),1x,i2.2,2(':',i2.2),5x,f16.9,3(1x,f14.6),3(1x,f12.8))
-130   format(4x,i4.4,2('-',i2.2),1x,i2.2,2(':',i2.2),5x,f16.9,7(1x,e16.9e2))
-140   format(4x,i4.4,2('-',i2.2),1x,i2.2,2(':',i2.2),5x,f16.9,1x,f9.2,2(1x,f8.3))
-150   format(4x,i4.4,2('-',i2.2),1x,i2.2,2(':',i2.2),5x,f16.9,6(1x,e15.8e2))
-160   format(4x,i4.4,2('-',i2.2),1x,i2.2,2(':',i2.2),5x,f16.9,15(1x,e15.8e2))
-170   format(4x,i4.4,2('-',i2.2),1x,i2.2,2(':',i2.2),5x,f16.9,1x,e15.8e2,x,f10.4,3(1x,f12.8))
+110   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,2x,f12.5,2x,f10.8,5(1x,f12.6))
+120   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,3(1x,f14.6),3(1x,f12.8))
+130   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,7(1x,e16.9e2))
+140   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,1x,f9.2,2(1x,f8.3))
+150   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,6(1x,e15.8e2))
+160   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,15(1x,e15.8e2))
+170   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,1x,e15.8e2,x,f10.4,3(1x,f12.8))
 
   end subroutine output
 

--- a/src/neptuneOutput.f90
+++ b/src/neptuneOutput.f90
@@ -1179,7 +1179,7 @@ contains
     call mjd2gd(epoch%mjd,epoch%year,epoch%month,epoch%day,fracday)
     call dayFraction2HMS(fracday,epoch%hour,epoch%minute,epoch%second)
     epoch_string = date2longstring(epoch)
-    write(99, *) 'the LEN_TIME is ', LEN_TIME_STRING_LONG
+
     do i = 1, size(this%output_arr)
 
       if(this%output_arr(i)%file_unit > 0) then
@@ -2158,7 +2158,7 @@ contains
         write(ich,'(A,$)') " Error Single Integration "
         write(ich,'(A)')   "     Call No. [Flag]      "
 
-        write(ich,'(A,$)') "#___[YYYY-MM-DD hh:mm:ss.ssssss]____"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DDThh:mm:ss.ssssssZ]"
         write(ich,'(A,$)') "_____[JD - 2400000.5]_____"
         write(ich,'(A,$)') "____________[s]___________"
         do i2 = 1,4
@@ -2205,7 +2205,7 @@ contains
         write(ich,'(A,$)') " Velocity-Y  "
         write(ich,'(A)')   " Velocity-Z "
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DDThh:mm:ss.ssssssZ]"
         write(ich,'(A,$)') "___[JD - 2400000.5]___"
 
         do i2 = 1,3
@@ -2260,7 +2260,7 @@ contains
         write(ich,'(A,$)') "    TRAN     "
         write(ich,'(A)')   "    MEAN     "
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DDThh:mm:ss.ssssssZ]"
         write(ich,'(A,$)') "___[JD - 2400000.5]___"
 
         write(ich,'(A,$)') "_____[km]____"
@@ -2432,7 +2432,7 @@ contains
         write(ich,'(A,$)') "     Acc.-W      "
         write(ich,'(A)')   "   Acc. Total    "
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DDThh:mm:ss.ssssssZ]"
         write(ich,'(A,$)') "___[JD - 2400000.5]___"
 
         do i2 = 1,7
@@ -2477,7 +2477,7 @@ contains
         write(ich,'(A,$)') "    Lat. "
         write(ich,'(A)')   "    Lon. "
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DDThh:mm:ss.ssssssZ]"
         write(ich,'(A,$)') "___[JD - 2400000.5]____"
         write(ich,'(A,$)') "_[km]___"
         write(ich,'(A,$)') "___[deg]_"
@@ -2519,7 +2519,7 @@ contains
         write(ich,'(A,$)') " Cross-section "
         write(ich,'(A)')   "          Rel. velocity"
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DDThh:mm:ss.ssssssZ]"
         write(ich,'(A,$)') "___[JD - 2400000.5]____"
         write(ich,'(A,$)') "__[g/cm**3]___"
         write(ich,'(A,$)') "___[m**2]___"

--- a/src/neptuneOutput.f90
+++ b/src/neptuneOutput.f90
@@ -65,7 +65,7 @@ module neptuneOutput
   use slam_strings,           only: toLowercase
   use thirdbody,              only: ThirdBody_class
   use tides,                  only: Tides_class, SOLID_TIDES, OCEAN_TIDES
-  use slam_time,              only: time_t, mjd2gd, dayFraction2hms, date2string
+  use slam_time,              only: time_t, mjd2gd, dayFraction2hms, date2string, date2longstring, LEN_TIME_STRING_LONG
   use slam_types,             only: dp
   use slam_units,             only: getUnitString, UNIT_RAD, C_UNIT_DEG
   use version,                only: Version_class
@@ -1153,7 +1153,6 @@ contains
     real(dp)                 :: alt                                             ! current altitude (km)
     real(dp)                 :: crossSection                                    ! cross-section / m**2
     real(dp)                 :: fracday                                         ! fraction of day (0<=fracday<1)
-    real(dp)                 :: dsec                                            ! second 
     real(dp), dimension(6,6) :: jacobi                                          ! jacobian matrix to convert covariance matrix from ECI to UVW system
     real(dp)                 :: lat                                             ! current latitude (degrees)
     real(dp)                 :: lon                                             ! current longitude (degrees)
@@ -1165,6 +1164,7 @@ contains
     type(covariance_t)   :: covar_out_uvw                                       ! covariance matrix in UVW frame
     type(kepler_t)       :: kepler                                              ! kepler elements
     type(time_t)         :: epoch                                               ! output epoch
+    character(LEN_TIME_STRING_LONG) :: epoch_string
 
     if(isControlled()) then
       if(hasToReturn()) return
@@ -1176,10 +1176,10 @@ contains
     flag_itrf    = .false.
 
     epoch%mjd = this%start_epoch%mjd + time_offset/86400.d0
-
     call mjd2gd(epoch%mjd,epoch%year,epoch%month,epoch%day,fracday)
-    call dayFraction2HMS(fracday,epoch%hour,epoch%minute,dsec)
-
+    call dayFraction2HMS(fracday,epoch%hour,epoch%minute,epoch%second)
+    epoch_string = date2longstring(epoch)
+    write(99, *) 'the LEN_TIME is ', LEN_TIME_STRING_LONG
     do i = 1, size(this%output_arr)
 
       if(this%output_arr(i)%file_unit > 0) then
@@ -1199,25 +1199,25 @@ contains
 
               case(ELLIPTICAL_INCLINED)
 
-                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+                write(this%output_arr(i)%file_unit,110) epoch_string, epoch%mjd,                                   &
                                     kepler%sma, kepler%ecc, kepler%inc*rad2deg, kepler%raan*rad2deg,               &
                                     kepler%aop*rad2deg, kepler%tran*rad2deg, kepler%man*rad2deg
 
               case(CIRCULAR_INCLINED)
 
-                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+                write(this%output_arr(i)%file_unit,110) epoch_string, epoch%mjd, &
                                     kepler%sma, kepler%ecc, kepler%inc*rad2deg, kepler%raan*rad2deg,               &
                                     0.d0, kepler%arglat*rad2deg, kepler%man*rad2deg
 
               case(ELLIPTICAL_EQUATORIAL)
 
-                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+                write(this%output_arr(i)%file_unit,110) epoch_string, epoch%mjd, &
                                     kepler%sma, kepler%ecc, kepler%inc*rad2deg, 0.d0, kepler%lonper*rad2deg,       &
                                     kepler%tran*rad2deg, kepler%man*rad2deg
 
               case(CIRCULAR_EQUATORIAL)
 
-                write(this%output_arr(i)%file_unit,110) epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+                write(this%output_arr(i)%file_unit,110) epoch_string, epoch%mjd, &
                                     kepler%sma, kepler%ecc, kepler%inc*rad2deg, 0.d0, 0.d0, kepler%truelon*rad2deg, &
                                     kepler%man*rad2deg
 
@@ -1225,14 +1225,14 @@ contains
 
           case(OUTPUT_CSV)  !** cartesian state vs. time
 
-            write(this%output_arr(i)%file_unit,120)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
+            write(this%output_arr(i)%file_unit,120)   epoch_string, epoch%mjd,   &
                                   state_out%r, state_out%v
 
           case(OUTPUT_VAR_ECI)  !** variances (diagonal elements of covariance matrix) in ECI frame vs. time
 
             if(numint%getCovariancePropagationFlag()) then
 
-              write(this%output_arr(i)%file_unit,150)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
+              write(this%output_arr(i)%file_unit,150)   epoch_string, epoch%mjd,   &
                                     (covar_out%elem(j,j), j=1,6)
 
             end if
@@ -1251,7 +1251,7 @@ contains
 
               end if
 
-              write(this%output_arr(i)%file_unit,150)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
+              write(this%output_arr(i)%file_unit,150)   epoch_string, epoch%mjd,   &
                                     (covar_out_uvw%elem(j,j), j=1,6)
                                    ! (sqrt(max(0.d0,covar_out_uvw%elem(j,j)))*1.d3, j=1,6)
 
@@ -1261,7 +1261,7 @@ contains
 
             if(numint%getCovariancePropagationFlag()) then
 
-              write(this%output_arr(i)%file_unit,160)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
+              write(this%output_arr(i)%file_unit,160)   epoch_string, epoch%mjd,   &
                                     ((covar_out%elem(j,k), k=1,j-1), j=2,6)
 
             end if
@@ -1280,7 +1280,7 @@ contains
 
               end if
 
-              write(this%output_arr(i)%file_unit,160)   epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd,   &
+              write(this%output_arr(i)%file_unit,160)   epoch_string, epoch%mjd,   &
                                     ((covar_out_uvw%elem(j,k), k=1,j-1), j=2,6)
 
             end if
@@ -1313,7 +1313,7 @@ contains
             !** convert acceleration to UVW coordinates
             call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-            write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+            write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                  (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
           case(OUTPUT_ACG) !** acceleration due to geopotential vs. time
@@ -1348,7 +1348,7 @@ contains
             !** convert acceleration to UVW coordinates
             call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-            write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+            write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                  (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
           case(OUTPUT_ACD)
@@ -1383,7 +1383,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1404,7 +1404,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1425,7 +1425,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1448,7 +1448,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1471,7 +1471,7 @@ contains
               !** convert acceleration to UVW coordinates
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1503,7 +1503,7 @@ contains
 
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1535,7 +1535,7 @@ contains
 
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1556,7 +1556,7 @@ contains
 
               call reduction%eci2uvw(state_out%r, state_out%v, acc_out, acc_out_uvw)
 
-              write(this%output_arr(i)%file_unit,130)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,130)  epoch_string, epoch%mjd, &
                                    (acc_out(j), j=1,3), (acc_out_uvw(j), j=1,3), mag(acc_out)
 
             end if
@@ -1585,7 +1585,7 @@ contains
               crossSection = satellite_model%getObjectCrossSection(solarsystem_model, reduction, epoch%mjd, state_out%r, v_rel)
               if(hasFailed()) return
 
-              write(this%output_arr(i)%file_unit,170)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, &
+              write(this%output_arr(i)%file_unit,170)  epoch_string, epoch%mjd, &
                                    rho, crossSection*1.d6, (v_rel(j), j=1,3)    ! '1.d6' for cross-section to convert to m**2
 
             end if
@@ -1624,7 +1624,7 @@ contains
 
             call getGeodeticLatLon(r_itrf, alt, lat, lon)
 
-            write(this%output_arr(i)%file_unit,140)  epoch%year, epoch%month, epoch%day, epoch%hour, epoch%minute, dsec, epoch%mjd, alt, lat*rad2deg, lon*rad2deg
+            write(this%output_arr(i)%file_unit,140)  epoch_string, epoch%mjd, alt, lat*rad2deg, lon*rad2deg
 
         end select
 
@@ -1639,13 +1639,15 @@ contains
       call checkOut(csubid)
     end if
 
-110   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,2x,f12.5,2x,f10.8,5(1x,f12.6))
-120   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,3(1x,f14.6),3(1x,f12.8))
-130   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,7(1x,e16.9e2))
-140   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,1x,f9.2,2(1x,f8.3))
-150   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,6(1x,e15.8e2))
-160   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,15(1x,e15.8e2))
-170   format(4x,i4.4,2('-',i2.2),1x,2(i2.2,':'),f9.6,5x,f16.9,1x,e15.8e2,x,f10.4,3(1x,f12.8))
+! Theoretically a value for epoch_string should be set as 27. But as it's a changing variable it's set 
+! as empty to import it from the length of epoch_string itself 
+110   format(4x,a,5x,f16.9,2x,f12.5,2x,f10.8,5(1x,f12.6))
+120   format(4x,a,5x,f16.9,3(1x,f14.6),3(1x,f12.8))
+130   format(4x,a,5x,f16.9,7(1x,e16.9e2))
+140   format(4x,a,5x,f16.9,1x,f9.2,2(1x,f8.3))
+150   format(4x,a,5x,f16.9,6(1x,e15.8e2))
+160   format(4x,a,5x,f16.9,15(1x,e15.8e2))
+170   format(4x,a,5x,f16.9,1x,e15.8e2,x,f10.4,3(1x,f12.8))
 
   end subroutine output
 
@@ -1724,8 +1726,8 @@ contains
     write(ich,'(A)')         '#  Input type:               '//trim(ctemp)
     write(ich,'(A)')         '#  Reference Frame:          '//C_REF_FRAME_GCRF
     write(ich,'(A)')         '#'
-    write(ich,'(a16,a20)')   '#  Begin epoch: ', trim(adjustl(date2string(this%start_epoch)))
-    write(ich,'(a16,a20)')   '#  End epoch:   ', trim(adjustl(date2string(this%end_epoch)))
+    write(ich,'(a16,a20)')   '#  Begin epoch: ', trim(adjustl(date2longstring(this%start_epoch)))
+    write(ich,'(a16,a20)')   '#  End epoch:   ', trim(adjustl(date2longstring(this%end_epoch)))
     write(ich,'(A)')         '#'
 
     if(this%isSetInitialState) then
@@ -2156,7 +2158,7 @@ contains
         write(ich,'(A,$)') " Error Single Integration "
         write(ich,'(A)')   "     Call No. [Flag]      "
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss]__"
+        write(ich,'(A,$)') "#___[YYYY-MM-DD hh:mm:ss.ssssss]____"
         write(ich,'(A,$)') "_____[JD - 2400000.5]_____"
         write(ich,'(A,$)') "____________[s]___________"
         do i2 = 1,4
@@ -2203,7 +2205,7 @@ contains
         write(ich,'(A,$)') " Velocity-Y  "
         write(ich,'(A)')   " Velocity-Z "
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
         write(ich,'(A,$)') "___[JD - 2400000.5]___"
 
         do i2 = 1,3
@@ -2258,7 +2260,7 @@ contains
         write(ich,'(A,$)') "    TRAN     "
         write(ich,'(A)')   "    MEAN     "
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
         write(ich,'(A,$)') "___[JD - 2400000.5]___"
 
         write(ich,'(A,$)') "_____[km]____"
@@ -2430,7 +2432,7 @@ contains
         write(ich,'(A,$)') "     Acc.-W      "
         write(ich,'(A)')   "   Acc. Total    "
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
         write(ich,'(A,$)') "___[JD - 2400000.5]___"
 
         do i2 = 1,7
@@ -2475,7 +2477,7 @@ contains
         write(ich,'(A,$)') "    Lat. "
         write(ich,'(A)')   "    Lon. "
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
         write(ich,'(A,$)') "___[JD - 2400000.5]____"
         write(ich,'(A,$)') "_[km]___"
         write(ich,'(A,$)') "___[deg]_"
@@ -2517,7 +2519,7 @@ contains
         write(ich,'(A,$)') " Cross-section "
         write(ich,'(A)')   "          Rel. velocity"
 
-        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss]"
+        write(ich,'(A,$)') "#_ [YYYY-MM-DD hh:mm:ss.ssssss]"
         write(ich,'(A,$)') "___[JD - 2400000.5]____"
         write(ich,'(A,$)') "__[g/cm**3]___"
         write(ich,'(A,$)') "___[m**2]___"

--- a/src/rdinp.f90
+++ b/src/rdinp.f90
@@ -125,10 +125,6 @@ subroutine rdinp(                &
   integer :: input_type_cov
   integer :: b_left, b_right    ! indices for version string parsing
 
-  real(dp)    :: dch_inp            ! input file channel 
-  real(dp)    :: dtemp              ! temporary
-  real(dp)    :: derr               ! error flag
-
   integer, dimension(100) :: distinctHarmonics
 
   real(dp), dimension(3) :: dtmp3
@@ -675,7 +671,7 @@ subroutine rdinp(                &
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp
-  derr =  neptune%setNeptuneVar("OUTPUT_STEP", ctemp)
+  ierr =  neptune%setNeptuneVar("OUTPUT_STEP", ctemp)
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp

--- a/src/rdinp.f90
+++ b/src/rdinp.f90
@@ -125,6 +125,10 @@ subroutine rdinp(                &
   integer :: input_type_cov
   integer :: b_left, b_right    ! indices for version string parsing
 
+  real(dp)    :: dch_inp            ! input file channel 
+  real(dp)    :: dtemp              ! temporary
+  real(dp)    :: derr               ! error flag
+
   integer, dimension(100) :: distinctHarmonics
 
   real(dp), dimension(3) :: dtmp3
@@ -671,11 +675,11 @@ subroutine rdinp(                &
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp
-  ierr =  neptune%setNeptuneVar("OUTPUT_STEP", ctemp)
+  derr =  neptune%setNeptuneVar("OUTPUT_STEP", ctemp)
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp
-  ierr =  neptune%setNeptuneVar("OPT_STORE_DATA", ctemp)
+  derr =  neptune%setNeptuneVar("OPT_STORE_DATA", ctemp)
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) itemp

--- a/src/rdinp.f90
+++ b/src/rdinp.f90
@@ -679,7 +679,7 @@ subroutine rdinp(                &
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) ctemp
-  derr =  neptune%setNeptuneVar("OPT_STORE_DATA", ctemp)
+  ierr =  neptune%setNeptuneVar("OPT_STORE_DATA", ctemp)
 
   call nxtbuf('#', 0, ich_inp, cbuf)
   read(cbuf,*) itemp

--- a/work/input/neptune.inp
+++ b/work/input/neptune.inp
@@ -57,8 +57,8 @@
 #     - gregorian date: YYYY MM DD HH MM SS.SSS... (separated by blanks)
 #     - julian day:     XXXXXXX.XX...              (no blanks)
 #
-  2016 07 20 00 31 50.00   2440980.0    Begin date
-  2016 08 03 00 31 50.00   2441345.0    End date
+  2016 07 20 00 31 00.00   2440980.0    Begin date
+  2016 08 03 00 31 00.00   2441345.0    End date
 #
 #------------------------------------------------------------------------------
 #
@@ -201,7 +201,7 @@
 #
 #   Output time step (in seconds)
 #
-  2.5
+  60.0
 #
 #   Time step for ephemerides in internal array (available via 'getNeptuneData' API)
 #   (in seconds - IF not '0' then output time step (above) will be overwritten by this

--- a/work/input/neptune.inp
+++ b/work/input/neptune.inp
@@ -201,7 +201,7 @@
 #
 #   Output time step (in seconds)
 #
-  2.5
+  60.0
 #
 #   Time step for ephemerides in internal array (available via 'getNeptuneData' API)
 #   (in seconds - IF not '0' then output time step (above) will be overwritten by this

--- a/work/input/neptune.inp
+++ b/work/input/neptune.inp
@@ -57,8 +57,8 @@
 #     - gregorian date: YYYY MM DD HH MM SS.SSS... (separated by blanks)
 #     - julian day:     XXXXXXX.XX...              (no blanks)
 #
-  2016 07 20 00 31 50.00   2440980.0    Begin date
-  2016 08 03 00 31 50.00   2441345.0    End date
+  2016 07 20 00 31 00.00   2440980.0    Begin date
+  2016 08 03 00 31 00.00   2441345.0    End date
 #
 #------------------------------------------------------------------------------
 #

--- a/work/input/neptune.inp
+++ b/work/input/neptune.inp
@@ -57,8 +57,8 @@
 #     - gregorian date: YYYY MM DD HH MM SS.SSS... (separated by blanks)
 #     - julian day:     XXXXXXX.XX...              (no blanks)
 #
-  2016 07 20 00 31 00.00   2440980.0    Begin date
-  2016 08 03 00 31 00.00   2441345.0    End date
+  2016 07 20 00 31 50.00   2440980.0    Begin date
+  2016 08 03 00 31 50.00   2441345.0    End date
 #
 #------------------------------------------------------------------------------
 #

--- a/work/input/neptune.inp
+++ b/work/input/neptune.inp
@@ -201,7 +201,7 @@
 #
 #   Output time step (in seconds)
 #
-  60
+  2.5
 #
 #   Time step for ephemerides in internal array (available via 'getNeptuneData' API)
 #   (in seconds - IF not '0' then output time step (above) will be overwritten by this

--- a/work/input/neptune.inp
+++ b/work/input/neptune.inp
@@ -201,7 +201,7 @@
 #
 #   Output time step (in seconds)
 #
-  60.0
+  2.5
 #
 #   Time step for ephemerides in internal array (available via 'getNeptuneData' API)
 #   (in seconds - IF not '0' then output time step (above) will be overwritten by this


### PR DESCRIPTION
Based on #36 

Now NEPTUNE uses a float to load the output step in the input file. This needs care as it might conflict with the OPI interface

Also, the output ISOT time includes now microseconds for more precision.