### PR TITLE
fix: update download URLs for DTCFILE and SOLFSMY  in start_neptune.sh

### DIFF
--- a/work/start_neptune.sh
+++ b/work/start_neptune.sh
@@ -17,10 +17,10 @@ if [[ `find "data/eop19620101.txt" -mtime +0` ]]; then
   mv ./data/EOP-All.txt ./data/eop19620101.txt
 fi
 if [[ `find "data/SOLFSMY.TXT" -mtime +0` ]]; then
-  wget -N http://sol.spacenvironment.net/~JB2008/indices/SOLFSMY.TXT --directory-prefix=./data
+  wget -N http://sol.spacenvironment.net/JB2008/indices/SOLFSMY.TXT --directory-prefix=./data
 fi
 if [[ `find "data/DTCFILE.TXT" -mtime +0` ]]; then
-  wget -N http://sol.spacenvironment.net/~JB2008/indices/DTCFILE.TXT --directory-prefix=./data
+  wget -N http://sol.spacenvironment.net/JB2008/indices/DTCFILE.TXT --directory-prefix=./data
 fi
 #
 # Create the output directory if it does not exist


### PR DESCRIPTION
This pull request includes changes to the `work/start_neptune.sh` script to update the URLs used for downloading data files. The most important changes include:

* Updated the URL for downloading `SOLFSMY.TXT` to remove the `~` character. (`[work/start_neptune.shL20-R23](diffhunk://#diff-90fa7eee1c92a84614ffb9fcfb52e1b975302482154ac6b137a98e1b953dc25dL20-R23)`)
* Updated the URL for downloading `DTCFILE.TXT` to remove the `~` character. (`[work/start_neptune.shL20-R23](diffhunk://#diff-90fa7eee1c92a84614ffb9fcfb52e1b975302482154ac6b137a98e1b953dc25dL20-R23)`)